### PR TITLE
fix: Useless window dimensions removed

### DIFF
--- a/include/common/Data.hpp
+++ b/include/common/Data.hpp
@@ -18,6 +18,8 @@ namespace arcade::common {
         std::vector<Sound> sounds;
         std::size_t score;
         std::size_t seconds;
+        std::size_t mapWith;
+        std::size_t mapHeight;
     };
 }
 

--- a/include/common/Elements.hpp
+++ b/include/common/Elements.hpp
@@ -29,11 +29,6 @@ namespace arcade::common {
         float y;
     };
 
-    struct WindowDimensions {
-        std::size_t width;
-        std::size_t height;
-    };
-
     struct Sprite {
         Position position;
         SpriteType type;

--- a/include/common/display/IDisplayModule.hpp
+++ b/include/common/display/IDisplayModule.hpp
@@ -18,7 +18,7 @@ namespace arcade::common {
         public:
             virtual ~IDisplayModule() = default;
 
-            virtual void display(const Data &data, const WindowDimensions &dimensions) = 0;
+            virtual void display(const Data &data) = 0;
             virtual std::optional<Input> getInput() = 0;
     };
 }

--- a/include/common/game/IGameModule.hpp
+++ b/include/common/game/IGameModule.hpp
@@ -18,7 +18,7 @@ namespace arcade::common {
             virtual ~IGameModule() = default;
 
             virtual void handleInput(Input in) = 0;
-            virtual Data &tick(const WindowDimensions &dimensions) = 0;
+            virtual Data &tick() = 0;
     };
 }
 


### PR DESCRIPTION
- Useless window dimension removed
- Replaced by an internal map in the game (the pos will be given in this map) and the map size is transmitted in the Data
- Displays will adapt the map size to the window size in pixels / chars