### PR TITLE
fix(position): Switched back to size_t

### DIFF
--- a/include/common/Elements.hpp
+++ b/include/common/Elements.hpp
@@ -25,8 +25,8 @@ namespace arcade::common {
     };
 
     struct Position {
-        float x;
-        float y;
+        size_t x;
+        size_t y;
     };
 
     struct Sprite {


### PR DESCRIPTION
Now that we are using case positions, it makes no sense to use floats.